### PR TITLE
ajustment of the permissions

### DIFF
--- a/src/domain/products/http/controllers/get-product-like-status.controller.ts
+++ b/src/domain/products/http/controllers/get-product-like-status.controller.ts
@@ -23,7 +23,7 @@ export class GetProductLikeStatusController {
 
   @Get(':id/like/status')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(PrismaRoles.ARTISAN, PrismaRoles.ADMIN, PrismaRoles.MODERATOR, PrismaRoles.USER)
+  @Roles(PrismaRoles.USER)
   async handle(@Param('id') productId: string, @CurrentUser() user: TokenPayload) {
     const result = await this.getProductLikeStatusUseCase.execute({
       productId,

--- a/src/domain/products/http/controllers/toggle-product-like.controller.ts
+++ b/src/domain/products/http/controllers/toggle-product-like.controller.ts
@@ -17,7 +17,7 @@ export class ToggleProductLikeController {
 
   @Post(':id/like')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(PrismaRoles.ARTISAN, PrismaRoles.ADMIN, PrismaRoles.MODERATOR, PrismaRoles.USER)
+  @Roles(PrismaRoles.USER)
   async handle(@Param('id') productId: string, @CurrentUser() user: TokenPayload) {
     const result = await this.toggleProductLikeUseCase.execute({ productId, userId: user.sub });
     if (result.isLeft()) {


### PR DESCRIPTION
This pull request restricts access to product like-related endpoints so that only users with the `USER` role can access them. Previously, multiple roles (including `ARTISAN`, `ADMIN`, and `MODERATOR`) could use these endpoints, but now only authenticated users with the `USER` role are permitted.

Access control changes for product like endpoints:

* Limited the `GET /:id/like/status` endpoint in `GetProductLikeStatusController` to only allow access for users with the `USER` role (`src/domain/products/http/controllers/get-product-like-status.controller.ts`).
* Limited the `POST /:id/like` endpoint in `ToggleProductLikeController` to only allow access for users with the `USER` role (`src/domain/products/http/controllers/toggle-product-like.controller.ts`).